### PR TITLE
Add gross-two-to-net calculation and expose totalCostToEmployer

### DIFF
--- a/packages/api/server/api/bruto/[net].get.ts
+++ b/packages/api/server/api/bruto/[net].get.ts
@@ -1,5 +1,6 @@
 import type { Place } from '@brutoneto/core'
 import {
+  grossToTotal,
   MAX_PERSONAL_ALLOWANCE_COEFFICIENT,
   MIN_PERSONAL_ALLOWANCE_COEFFICIENT,
   netToGross,
@@ -66,10 +67,12 @@ export default defineEventHandler(async (event) => {
     taxRateHigh: htax,
     personalAllowanceCoefficient: coeff,
   })
+  const { total: totalCostToEmployer } = grossToTotal(gross)
 
   return {
     net,
     gross,
+    totalCostToEmployer,
     currency: 'EUR',
   }
 })

--- a/packages/api/server/api/neto/[gross].get.ts
+++ b/packages/api/server/api/neto/[gross].get.ts
@@ -2,6 +2,7 @@ import type { Place, SalaryConfig } from '@brutoneto/core'
 import {
   grossToNet,
   grossToNetBreakdown,
+  grossToTotal,
   MAX_PERSONAL_ALLOWANCE_COEFFICIENT,
   MIN_PERSONAL_ALLOWANCE_COEFFICIENT,
   roundEuros,
@@ -91,9 +92,11 @@ export default defineEventHandler(async (event) => {
   }
 
   const net = grossToNet(monthlyGross, grossToNetConfig)
+  const { total: totalCostToEmployer } = grossToTotal(monthlyGross)
 
   return {
     gross: monthlyGross,
+    totalCostToEmployer,
     net,
     currency: 'EUR',
   }

--- a/packages/api/server/api/neto/bruto2/[grossTwo].get.ts
+++ b/packages/api/server/api/neto/bruto2/[grossTwo].get.ts
@@ -1,0 +1,99 @@
+import type { Place, SalaryConfig } from '@brutoneto/core'
+import {
+  grossTwoToNet,
+  grossTwoToNetBreakdown,
+  MAX_PERSONAL_ALLOWANCE_COEFFICIENT,
+  MIN_PERSONAL_ALLOWANCE_COEFFICIENT,
+  roundEuros,
+  THIRD_PILLAR_NON_TAXABLE_LIMIT,
+} from '@brutoneto/core'
+import { getQuery, getRouterParams } from 'h3'
+import { z } from 'zod'
+import { isValidPlaceWithShortcuts, resolvePlaceShortcut } from '~/utils/places'
+
+const ParamsSchema = z.object({
+  grossTwo: z.coerce.number().positive(),
+})
+
+const QuerySchema = z.object({
+  place: z
+    .string()
+    .refine(isValidPlaceWithShortcuts, {
+      message: 'Invalid place',
+    })
+    .optional(),
+  ltax: z.coerce.number().min(0).max(0.99).optional(),
+  htax: z.coerce.number().min(0).max(0.99).optional(),
+  coeff: z
+    .coerce
+    .number()
+    .min(MIN_PERSONAL_ALLOWANCE_COEFFICIENT)
+    .max(MAX_PERSONAL_ALLOWANCE_COEFFICIENT)
+    .optional(),
+  third_pillar: z
+    .coerce
+    .number()
+    .min(0)
+    .max(THIRD_PILLAR_NON_TAXABLE_LIMIT, {
+      message: `Maximum allowed non-taxable monthly third pillar contribution is €${THIRD_PILLAR_NON_TAXABLE_LIMIT}`,
+    })
+    .optional(),
+  detailed: z.coerce.boolean().optional(),
+  yearly: z.coerce.boolean().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const routerParams = getRouterParams(event)
+  const params = ParamsSchema.safeParse(routerParams)
+
+  if (params.success === false) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid gross two amount',
+      message: extractZodErrorMessage(params.error),
+    })
+  }
+
+  const { grossTwo } = params.data
+
+  const queryParams = getQuery(event)
+  const query = QuerySchema.safeParse(queryParams)
+
+  if (query.success === false) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid query parameter(s)',
+      message: extractZodErrorMessage(query.error),
+    })
+  }
+
+  const { place, ltax, htax, coeff, third_pillar, detailed, yearly } = query.data
+
+  const monthlyGrossTwo = yearly === true ? roundEuros(grossTwo / 12) : grossTwo
+
+  const resolvedPlace = place != null ? resolvePlaceShortcut(place) as Place : undefined
+
+  const config: SalaryConfig = {
+    place: resolvedPlace,
+    taxRateLow: ltax,
+    taxRateHigh: htax,
+    personalAllowanceCoefficient: coeff,
+    thirdPillarContribution: third_pillar,
+  }
+
+  if (detailed === true) {
+    const res = grossTwoToNetBreakdown(monthlyGrossTwo, config)
+    return {
+      ...res,
+      currency: 'EUR',
+    }
+  }
+
+  const net = grossTwoToNet(monthlyGrossTwo, config)
+
+  return {
+    grossTwo: monthlyGrossTwo,
+    net,
+    currency: 'EUR',
+  }
+})

--- a/packages/api/server/api/neto/bruto2/[grossTwo].get.ts
+++ b/packages/api/server/api/neto/bruto2/[grossTwo].get.ts
@@ -6,6 +6,7 @@ import {
   MIN_PERSONAL_ALLOWANCE_COEFFICIENT,
   roundEuros,
   THIRD_PILLAR_NON_TAXABLE_LIMIT,
+  totalToGross,
 } from '@brutoneto/core'
 import { getQuery, getRouterParams } from 'h3'
 import { z } from 'zod'
@@ -90,9 +91,11 @@ export default defineEventHandler(async (event) => {
   }
 
   const net = grossTwoToNet(monthlyGrossTwo, config)
+  const gross = totalToGross(monthlyGrossTwo)
 
   return {
-    grossTwo: monthlyGrossTwo,
+    totalCostToEmployer: monthlyGrossTwo,
+    gross,
     net,
     currency: 'EUR',
   }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -11,12 +11,19 @@ export {
   type NetToGrossConfig,
 } from './src/calculations/net-to-gross'
 
+// Gross-two-to-net calculation
+export {
+  grossTwoToNet,
+  grossTwoToNetBreakdown,
+} from './src/calculations/gross-two-to-net'
+
 // Calculation utilities (for custom calculations)
 export {
   calcMandatoryPensionContribution,
   calcPersonalAllowance,
   calcTax,
   grossToTotal,
+  totalToGross,
 } from './src/calculations/salary'
 
 export {

--- a/packages/core/src/calculations/gross-two-to-net.test.ts
+++ b/packages/core/src/calculations/gross-two-to-net.test.ts
@@ -40,12 +40,12 @@ describe('grossTwoToNet', () => {
 })
 
 describe('grossTwoToNetBreakdown', () => {
-  it('should return breakdown with grossTwo field included', () => {
+  it('should return breakdown with correct totalCostToEmployer, gross, and net', () => {
     const gross = 4000
     const { total: grossTwo } = grossToTotal(gross)
 
     const result = grossTwoToNetBreakdown(grossTwo)
-    expect(result.grossTwo).toBe(grossTwo)
+    expect(result.totalCostToEmployer).toBe(grossTwo)
     expect(result.gross).toBe(gross)
     expect(result.net).toBe(grossToNet(gross))
   })
@@ -71,6 +71,6 @@ describe('grossTwoToNetBreakdown', () => {
 
     const result = grossTwoToNetBreakdown(grossTwo, { place: 'zagreb' })
     expect(result.variables.place).toBe('zagreb')
-    expect(result.grossTwo).toBe(grossTwo)
+    expect(result.totalCostToEmployer).toBe(grossTwo)
   })
 })

--- a/packages/core/src/calculations/gross-two-to-net.test.ts
+++ b/packages/core/src/calculations/gross-two-to-net.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { grossToNet, grossToNetBreakdown } from './gross-to-net'
+import { grossTwoToNet, grossTwoToNetBreakdown } from './gross-two-to-net'
+import { grossToTotal } from './salary'
+
+describe('grossTwoToNet', () => {
+  it('should calculate correct net from grossTwo using default tax rates', () => {
+    const gross = 4000
+    const { total: grossTwo } = grossToTotal(gross)
+    const expectedNet = grossToNet(gross)
+
+    const result = grossTwoToNet(grossTwo)
+    expect(result).toBe(expectedNet)
+  })
+
+  it('should calculate correct net from grossTwo for a defined place', () => {
+    const gross = 4000
+    const { total: grossTwo } = grossToTotal(gross)
+    const expectedNet = grossToNet(gross, { place: 'sveta-nedelja-samobor' })
+
+    const result = grossTwoToNet(grossTwo, { place: 'sveta-nedelja-samobor' })
+    expect(result).toBe(expectedNet)
+  })
+
+  it('should be consistent with grossToNet through grossToTotal roundtrip', () => {
+    const testGrossValues = [1000, 2500, 3000, 4000, 5000, 6000, 8000, 10000]
+
+    for (const gross of testGrossValues) {
+      const { total: grossTwo } = grossToTotal(gross)
+      const expectedNet = grossToNet(gross)
+      const result = grossTwoToNet(grossTwo)
+      expect(result, `Failed for gross=${gross}, grossTwo=${grossTwo}`).toBe(expectedNet)
+    }
+  })
+
+  it('should throw for invalid grossTwo values', () => {
+    expect(() => grossTwoToNet(-1)).toThrow()
+    expect(() => grossTwoToNet(Infinity)).toThrow()
+  })
+})
+
+describe('grossTwoToNetBreakdown', () => {
+  it('should return breakdown with grossTwo field included', () => {
+    const gross = 4000
+    const { total: grossTwo } = grossToTotal(gross)
+
+    const result = grossTwoToNetBreakdown(grossTwo)
+    expect(result.grossTwo).toBe(grossTwo)
+    expect(result.gross).toBe(gross)
+    expect(result.net).toBe(grossToNet(gross))
+  })
+
+  it('should match grossToNetBreakdown results for equivalent gross', () => {
+    const gross = 5000
+    const { total: grossTwo } = grossToTotal(gross)
+
+    const fromGrossTwo = grossTwoToNetBreakdown(grossTwo)
+    const fromGross = grossToNetBreakdown(gross)
+
+    expect(fromGrossTwo.net).toBe(fromGross.net)
+    expect(fromGrossTwo.gross).toBe(fromGross.gross)
+    expect(fromGrossTwo.totalCostToEmployer).toBe(fromGross.totalCostToEmployer)
+    expect(fromGrossTwo.pension).toEqual(fromGross.pension)
+    expect(fromGrossTwo.taxes).toEqual(fromGross.taxes)
+    expect(fromGrossTwo.healthInsurance).toBe(fromGross.healthInsurance)
+  })
+
+  it('should support place configuration', () => {
+    const gross = 4000
+    const { total: grossTwo } = grossToTotal(gross)
+
+    const result = grossTwoToNetBreakdown(grossTwo, { place: 'zagreb' })
+    expect(result.variables.place).toBe('zagreb')
+    expect(result.grossTwo).toBe(grossTwo)
+  })
+})

--- a/packages/core/src/calculations/gross-two-to-net.ts
+++ b/packages/core/src/calculations/gross-two-to-net.ts
@@ -1,0 +1,42 @@
+import type { SalaryConfig } from './gross-to-net'
+import { RATE } from '../constants'
+import { Decimal } from '../lib/decimal'
+import { assertValidSalary, roundEuros } from '../utils/precision'
+import { grossToNet, grossToNetBreakdown } from './gross-to-net'
+import { totalToGross } from './salary'
+
+/**
+ * Calculates the net income from the total cost to employer (bruto 2).
+ *
+ * @alias bruto2ToNeto
+ *
+ * @param grossTwo - The total cost to employer (bruto 2) in euros.
+ * @param config - Optional configuration for tax rates and personal allowance coefficient.
+ * @returns The net income in euros (rounded to 2 decimal places).
+ *
+ * @example
+ * const net = grossTwoToNet(4660) // gross1 ≈ 4000, net ≈ 2680
+ */
+export function grossTwoToNet(grossTwo: number, config: SalaryConfig = {}): number {
+  assertValidSalary(grossTwo, 'grossTwo', 1_165_000)
+  const gross = totalToGross(grossTwo)
+  return grossToNet(gross, config)
+}
+
+/**
+ * Calculates comprehensive salary breakdown from the total cost to employer (bruto 2).
+ *
+ * @param grossTwo - The total cost to employer (bruto 2) in euros.
+ * @param config - Optional configuration object.
+ * @returns An object containing detailed salary breakdown including the original grossTwo input.
+ */
+export function grossTwoToNetBreakdown(grossTwo: number, config: SalaryConfig = {}) {
+  assertValidSalary(grossTwo, 'grossTwo', 1_165_000)
+  const gross = totalToGross(grossTwo)
+  const breakdown = grossToNetBreakdown(gross, config)
+
+  return {
+    ...breakdown,
+    grossTwo: roundEuros(grossTwo),
+  }
+}

--- a/packages/core/src/calculations/gross-two-to-net.ts
+++ b/packages/core/src/calculations/gross-two-to-net.ts
@@ -1,7 +1,5 @@
 import type { SalaryConfig } from './gross-to-net'
-import { RATE } from '../constants'
-import { Decimal } from '../lib/decimal'
-import { assertValidSalary, roundEuros } from '../utils/precision'
+import { assertValidSalary } from '../utils/precision'
 import { grossToNet, grossToNetBreakdown } from './gross-to-net'
 import { totalToGross } from './salary'
 
@@ -10,33 +8,28 @@ import { totalToGross } from './salary'
  *
  * @alias bruto2ToNeto
  *
- * @param grossTwo - The total cost to employer (bruto 2) in euros.
+ * @param totalCost - The total cost to employer (bruto 2) in euros.
  * @param config - Optional configuration for tax rates and personal allowance coefficient.
  * @returns The net income in euros (rounded to 2 decimal places).
  *
  * @example
  * const net = grossTwoToNet(4660) // gross1 ≈ 4000, net ≈ 2680
  */
-export function grossTwoToNet(grossTwo: number, config: SalaryConfig = {}): number {
-  assertValidSalary(grossTwo, 'grossTwo', 1_165_000)
-  const gross = totalToGross(grossTwo)
+export function grossTwoToNet(totalCost: number, config: SalaryConfig = {}): number {
+  assertValidSalary(totalCost, 'totalCostToEmployer', 1_165_000)
+  const gross = totalToGross(totalCost)
   return grossToNet(gross, config)
 }
 
 /**
  * Calculates comprehensive salary breakdown from the total cost to employer (bruto 2).
  *
- * @param grossTwo - The total cost to employer (bruto 2) in euros.
+ * @param totalCost - The total cost to employer (bruto 2) in euros.
  * @param config - Optional configuration object.
- * @returns An object containing detailed salary breakdown including the original grossTwo input.
+ * @returns An object containing detailed salary breakdown.
  */
-export function grossTwoToNetBreakdown(grossTwo: number, config: SalaryConfig = {}) {
-  assertValidSalary(grossTwo, 'grossTwo', 1_165_000)
-  const gross = totalToGross(grossTwo)
-  const breakdown = grossToNetBreakdown(gross, config)
-
-  return {
-    ...breakdown,
-    grossTwo: roundEuros(grossTwo),
-  }
+export function grossTwoToNetBreakdown(totalCost: number, config: SalaryConfig = {}) {
+  assertValidSalary(totalCost, 'totalCostToEmployer', 1_165_000)
+  const gross = totalToGross(totalCost)
+  return grossToNetBreakdown(gross, config)
 }

--- a/packages/core/src/calculations/salary.ts
+++ b/packages/core/src/calculations/salary.ts
@@ -129,6 +129,22 @@ export function calcHealthInsuranceContribution(gross: number): number {
 }
 
 /**
+ * Calculates the gross (bruto 1) amount from the total cost to employer (bruto 2).
+ * Reverse of grossToTotal.
+ *
+ * @note bruto 2 u bruto 1
+ *
+ * @param total - The total cost to employer (bruto 2).
+ * @returns The gross (bruto 1) amount.
+ */
+export function totalToGross(total: number): number {
+  return new Decimal(total)
+    .div(new Decimal(1).add(RATE.HEALTH_INSURANCE_CONTRIBUTION))
+    .toDP(2)
+    .toNumber()
+}
+
+/**
  * Calculates the total amount by adding the gross amount and the health insurance contribution.
  *
  * @param gross - The gross amount.


### PR DESCRIPTION
## Summary
This PR adds support for calculating net income from the total cost to employer (bruto 2) and exposes the total cost to employer in existing salary calculation endpoints.

## Key Changes
- **New calculation functions**: Added `grossTwoToNet()` and `grossTwoToNetBreakdown()` functions to convert total cost to employer (bruto 2) to net income
- **New API endpoint**: Created `/api/neto/bruto2/[grossTwo].get.ts` endpoint that accepts total cost to employer and returns net salary with optional detailed breakdown
- **Reverse calculation utility**: Added `totalToGross()` function to calculate gross (bruto 1) from total cost to employer (bruto 2), implementing the reverse of the existing `grossToTotal()` function
- **Enhanced existing endpoints**: Updated `/api/bruto/[net].get.ts` and `/api/neto/[gross].get.ts` to include `totalCostToEmployer` in their responses
- **Comprehensive test coverage**: Added 76 lines of test cases for the new `grossTwoToNet` functions, validating consistency with existing calculations and edge cases
- **Core exports**: Exported new functions and utilities from the core package index

## Implementation Details
- The new endpoint supports all existing configuration options: place, tax rates (ltax/htax), personal allowance coefficient, and third pillar contributions
- Supports both monthly and yearly calculations via the `yearly` query parameter
- Includes optional `detailed` parameter for comprehensive salary breakdown
- All calculations maintain consistency with existing salary calculation logic through the `totalToGross()` reverse transformation
- Input validation uses Zod schemas with appropriate constraints and error messages

https://claude.ai/code/session_0173VRCEVkwxgQP4L6Gwy9an