### PR TITLE
Add support for Bruto 2 (total employer cost) salary calculations

### DIFF
--- a/packages/web/app/components/SalaryCalculator.vue
+++ b/packages/web/app/components/SalaryCalculator.vue
@@ -3,9 +3,11 @@ import type { Place } from '@brutoneto/core'
 import { useClipboard, useStorage } from '@vueuse/core'
 
 type Mode = 'gross-to-net' | 'net-to-gross'
+type BrutoType = 'bruto1' | 'bruto2'
 
 type Props = {
   mode: Mode
+  brutoType: BrutoType
   selectedPlaceKey: Place
   period: 'yearly' | 'monthly'
   placeholder?: string
@@ -44,19 +46,31 @@ const inputRef = ref<any>(null)
 const getInputEl = () =>
   (inputRef.value?.$el as HTMLElement | undefined)?.querySelector?.('input') as HTMLInputElement | null
 
-const endpoint = computed(() => (mode.value === 'gross-to-net' ? 'neto' : 'bruto'))
+const endpoint = computed(() => {
+  if (mode.value === 'gross-to-net' && props.brutoType === 'bruto2') return 'neto/bruto2'
+  if (mode.value === 'net-to-gross') return 'bruto'
+  return 'neto'
+})
 const toYearly = (value: number) => value * 12
 const amountNumber = computed(() => Number(amount.value))
 const lastSubmittedAmount = ref<number | null>(null)
 const lastSubmittedPeriod = ref<'yearly' | 'monthly' | null>(null)
 const amountLabel = computed(() => {
   const periodLabel = period.value === 'yearly' ? 'Yearly' : 'Monthly'
-  return mode.value === 'gross-to-net'
-    ? `${periodLabel} gross amount`
-    : `${periodLabel} net amount`
+  if (mode.value === 'gross-to-net') {
+    return props.brutoType === 'bruto2'
+      ? `${periodLabel} gross 2 amount (total employer cost)`
+      : `${periodLabel} gross amount`
+  }
+  return `${periodLabel} net amount`
 })
 const grossYearly = computed(() => {
-  if (lastSubmittedPeriod.value === 'yearly' && lastSubmittedAmount.value != null) {
+  if (
+    mode.value === 'gross-to-net'
+    && props.brutoType === 'bruto1'
+    && lastSubmittedPeriod.value === 'yearly'
+    && lastSubmittedAmount.value != null
+  ) {
     return lastSubmittedAmount.value
   }
   return toYearly(data.value?.gross ?? 0)
@@ -85,6 +99,16 @@ const { data, execute: calculate } = useFetch<{ net: number, gross: number }>(
 
 watch(
   () => selectedPlaceKey.value,
+  () => {
+    if (!hasSubmittedOnce.value || !isInputValid.value) {
+      return
+    }
+    handleCalculate()
+  },
+)
+
+watch(
+  () => props.brutoType,
   () => {
     if (!hasSubmittedOnce.value || !isInputValid.value) {
       return

--- a/packages/web/app/components/SalaryCalculator.vue
+++ b/packages/web/app/components/SalaryCalculator.vue
@@ -175,6 +175,10 @@ const percentChips = [
 watch(
   () => mode.value,
   async () => {
+    data.value = null
+    hasSubmittedOnce.value = false
+    lastSubmittedAmount.value = null
+    lastSubmittedPeriod.value = null
     await nextTick()
     getInputEl()?.focus()
   },

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -14,6 +14,7 @@ const mode = computed<Mode>({
     } else {
       delete params.mode
     }
+    delete params.bruto
   },
 })
 const isActiveMode = (value: Mode) => mode.value === value

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -2,6 +2,7 @@
 import type { Place } from '@brutoneto/core'
 
 type Mode = 'gross-to-net' | 'net-to-gross'
+type BrutoType = 'bruto1' | 'bruto2'
 
 const params = useUrlSearchParams('history')
 
@@ -16,6 +17,16 @@ const mode = computed<Mode>({
   },
 })
 const isActiveMode = (value: Mode) => mode.value === value
+const brutoType = computed<BrutoType>({
+  get: () => (params.bruto === '2' ? 'bruto2' : 'bruto1'),
+  set: (value) => {
+    if (value === 'bruto2') {
+      params.bruto = '2'
+    } else {
+      delete params.bruto
+    }
+  },
+})
 const selectedPlaceKey = useCookie<Place>('place', {
   default: () => 'sveta-nedelja-samobor',
 })
@@ -105,14 +116,31 @@ const places = computed(() => taxesRes.value?.places)
             </template>
           </USelectMenu>
         </UFormField>
+        <UFormField
+          v-if="isActiveMode('gross-to-net')"
+          label="Type"
+          :ui="{ label: 'text-sm' }"
+        >
+          <USelect
+            v-model="brutoType"
+            class="w-full sm:w-36"
+            :ui="{ content: 'w-full sm:w-36' }"
+            :items="[
+              { label: 'Bruto 1', value: 'bruto1' },
+              { label: 'Bruto 2', value: 'bruto2' },
+            ]"
+            size="lg"
+          />
+        </UFormField>
       </div>
 
       <section class="mt-3">
         <SalaryCalculator
           v-model:period="period"
           :mode="mode"
+          :bruto-type="isActiveMode('gross-to-net') ? brutoType : 'bruto1'"
           :selected-place-key="selectedPlaceKey"
-          :placeholder="isActiveMode('gross-to-net') ? '3000' : '2200'"
+          :placeholder="isActiveMode('gross-to-net') ? (brutoType === 'bruto2' ? '4660' : '3000') : '2200'"
           autofocus
         />
       </section>


### PR DESCRIPTION
## Summary
This PR adds support for calculating salaries based on "Bruto 2" (total employer cost) in addition to the existing "Bruto 1" calculation. Users can now toggle between these two gross salary types when performing gross-to-net calculations.

## Key Changes
- Added `BrutoType` type definition (`'bruto1' | 'bruto2'`) to both the main page and SalaryCalculator component
- Introduced a new "Type" dropdown selector in the UI that appears only in gross-to-net mode, allowing users to choose between Bruto 1 and Bruto 2
- Updated the API endpoint logic to route to `'neto/bruto2'` when calculating from Bruto 2, while maintaining backward compatibility with existing Bruto 1 calculations
- Enhanced the amount label to display "gross 2 amount (total employer cost)" when Bruto 2 is selected
- Added URL parameter persistence (`bruto` query param) to remember the user's Bruto type selection
- Implemented a watcher to automatically recalculate when the Bruto type changes
- Updated placeholder values to reflect different defaults for Bruto 1 (3000) vs Bruto 2 (4660)
- Modified the `grossYearly` computed property to only apply yearly caching for Bruto 1 mode

## Implementation Details
- The Bruto type selection is only visible when in "gross-to-net" mode and defaults to Bruto 1
- URL search parameters are used to persist the user's selection across page reloads
- The component intelligently recalculates only when necessary (after initial submission and when input is valid)

https://claude.ai/code/session_01Ab7G8NBxUBnBgB99m4jrvL