### PR TITLE
Add d.o.o. (Croatian LLC) salary + dividend calculator

### DIFF
--- a/packages/api/server/api/doo/[totalRevenue].get.ts
+++ b/packages/api/server/api/doo/[totalRevenue].get.ts
@@ -1,0 +1,103 @@
+import type { DooConfig, Place } from '@brutoneto/core'
+import {
+  calculateDoo,
+  DIRECTOR_MINIMUM_GROSS,
+  MAX_PERSONAL_ALLOWANCE_COEFFICIENT,
+  MIN_PERSONAL_ALLOWANCE_COEFFICIENT,
+  roundEuros,
+  THIRD_PILLAR_NON_TAXABLE_LIMIT,
+} from '@brutoneto/core'
+import { getQuery, getRouterParams } from 'h3'
+import { z } from 'zod'
+import { isValidPlaceWithShortcuts, resolvePlaceShortcut } from '~/utils/places'
+
+const ParamsSchema = z.object({
+  totalRevenue: z.coerce.number().positive(),
+})
+
+const QuerySchema = z.object({
+  salary_gross: z.coerce.number().positive().optional(),
+  place: z
+    .string()
+    .refine(isValidPlaceWithShortcuts, {
+      message: 'Invalid place',
+    })
+    .optional(),
+  ltax: z.coerce.number().min(0).max(0.99).optional(),
+  htax: z.coerce.number().min(0).max(0.99).optional(),
+  coeff: z
+    .coerce
+    .number()
+    .min(MIN_PERSONAL_ALLOWANCE_COEFFICIENT)
+    .max(MAX_PERSONAL_ALLOWANCE_COEFFICIENT)
+    .optional(),
+  third_pillar: z
+    .coerce
+    .number()
+    .min(0)
+    .max(THIRD_PILLAR_NON_TAXABLE_LIMIT, {
+      message: `Maximum allowed non-taxable monthly third pillar contribution is €${THIRD_PILLAR_NON_TAXABLE_LIMIT}`,
+    })
+    .optional(),
+  detailed: z.coerce.boolean().optional(),
+  yearly: z.coerce.boolean().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const routerParams = getRouterParams(event)
+  const params = ParamsSchema.safeParse(routerParams)
+
+  if (params.success === false) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid total revenue amount',
+      message: extractZodErrorMessage(params.error),
+    })
+  }
+
+  const { totalRevenue } = params.data
+
+  const queryParams = getQuery(event)
+  const query = QuerySchema.safeParse(queryParams)
+
+  if (query.success === false) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid query parameter(s)',
+      message: extractZodErrorMessage(query.error),
+    })
+  }
+
+  const { salary_gross, place, ltax, htax, coeff, third_pillar, detailed, yearly } = query.data
+
+  const monthlyRevenue = yearly === true ? roundEuros(totalRevenue / 12) : totalRevenue
+
+  const resolvedPlace = place != null ? resolvePlaceShortcut(place) as Place : undefined
+
+  const dooConfig: DooConfig = {
+    directorGross: salary_gross ?? DIRECTOR_MINIMUM_GROSS,
+    place: resolvedPlace,
+    taxRateLow: ltax,
+    taxRateHigh: htax,
+    personalAllowanceCoefficient: coeff,
+    thirdPillarContribution: third_pillar,
+  }
+
+  if (detailed === true) {
+    const res = calculateDoo(monthlyRevenue, dooConfig)
+    return {
+      ...res,
+      currency: 'EUR',
+    }
+  }
+
+  const res = calculateDoo(monthlyRevenue, dooConfig)
+  return {
+    totalRevenue: monthlyRevenue,
+    directorGross: res.directorGross,
+    netSalary: res.totals.netSalary,
+    netDividend: res.totals.netDividend,
+    total: res.totals.monthlyNet,
+    currency: 'EUR',
+  }
+})

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,3 +1,11 @@
+// DOO (d.o.o.) calculations
+export {
+  calculateDoo,
+  calculateDooSimple,
+  type DooBreakdown,
+  type DooConfig,
+} from './src/calculations/doo'
+
 // Main salary calculations
 export {
   grossToNet,
@@ -5,17 +13,17 @@ export {
   type SalaryConfig,
 } from './src/calculations/gross-to-net'
 
-// Net-to-gross calculation
-export {
-  netToGross,
-  type NetToGrossConfig,
-} from './src/calculations/net-to-gross'
-
 // Gross-two-to-net calculation
 export {
   grossTwoToNet,
   grossTwoToNetBreakdown,
 } from './src/calculations/gross-two-to-net'
+
+// Net-to-gross calculation
+export {
+  netToGross,
+  type NetToGrossConfig,
+} from './src/calculations/net-to-gross'
 
 // Calculation utilities (for custom calculations)
 export {
@@ -28,6 +36,9 @@ export {
 
 export {
   BASIC_PERSONAL_ALLOWANCE,
+  CORPORATE_TAX_RATE,
+  DIRECTOR_MINIMUM_GROSS,
+  DIVIDEND_TAX_RATE,
   HIGH_TAX_BRACKET_THRESHOLD,
   MAX_PERSONAL_ALLOWANCE_COEFFICIENT,
   MIN_PERSONAL_ALLOWANCE_COEFFICIENT,

--- a/packages/core/src/calculations/doo.test.ts
+++ b/packages/core/src/calculations/doo.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { CORPORATE_TAX_RATE, DIRECTOR_MINIMUM_GROSS, DIVIDEND_TAX_RATE } from '../constants'
+import { roundEuros } from '../utils/precision'
+import { calculateDoo, calculateDooSimple } from './doo'
+import { grossToNet, grossToNetBreakdown } from './gross-to-net'
+import { grossToTotal } from './salary'
+
+describe('calculateDoo', () => {
+  it('should use director minimum gross by default', () => {
+    const result = calculateDoo(5000)
+    expect(result.directorGross).toBe(DIRECTOR_MINIMUM_GROSS)
+    expect(result.variables.isDirectorMinimum).toBe(true)
+  })
+
+  it('should calculate correct salary net using existing grossToNet', () => {
+    const result = calculateDoo(5000)
+    const expectedNet = grossToNet(DIRECTOR_MINIMUM_GROSS)
+    expect(result.salary.net).toBe(expectedNet)
+    expect(result.totals.netSalary).toBe(expectedNet)
+  })
+
+  it('should calculate correct bruto2 from grossToTotal', () => {
+    const result = calculateDoo(5000)
+    const { total: expectedBruto2 } = grossToTotal(DIRECTOR_MINIMUM_GROSS)
+    expect(result.salary.totalCostToEmployer).toBe(expectedBruto2)
+  })
+
+  it('should match grossToNetBreakdown salary results exactly', () => {
+    const directorGross = 2000
+    const result = calculateDoo(8000, { directorGross })
+    const directBreakdown = grossToNetBreakdown(directorGross)
+
+    expect(result.salary.net).toBe(directBreakdown.net)
+    expect(result.salary.gross).toBe(directBreakdown.gross)
+    expect(result.salary.totalCostToEmployer).toBe(directBreakdown.totalCostToEmployer)
+    expect(result.salary.pension).toEqual(directBreakdown.pension)
+    expect(result.salary.taxes).toEqual(directBreakdown.taxes)
+    expect(result.salary.healthInsurance).toBe(directBreakdown.healthInsurance)
+  })
+
+  it('should apply 10% corporate tax rate', () => {
+    const result = calculateDoo(5000)
+    expect(result.corporate.corporateTaxRate).toBe(CORPORATE_TAX_RATE)
+
+    const expectedTax = roundEuros(result.corporate.profit * CORPORATE_TAX_RATE)
+    expect(result.corporate.corporateTax).toBe(expectedTax)
+    expect(result.corporate.profitAfterTax).toBe(
+      roundEuros(result.corporate.profit - result.corporate.corporateTax),
+    )
+  })
+
+  it('should apply 12% dividend tax rate', () => {
+    const result = calculateDoo(5000)
+    expect(result.dividend.dividendTaxRate).toBe(DIVIDEND_TAX_RATE)
+
+    const expectedDividendTax = roundEuros(result.corporate.profitAfterTax * DIVIDEND_TAX_RATE)
+    expect(result.dividend.dividendTax).toBe(expectedDividendTax)
+    expect(result.dividend.netDividend).toBe(
+      roundEuros(result.corporate.profitAfterTax - result.dividend.dividendTax),
+    )
+  })
+
+  it('should calculate correct totals', () => {
+    const result = calculateDoo(5000)
+    expect(result.totals.monthlyNet).toBe(
+      roundEuros(result.totals.netSalary + result.totals.netDividend),
+    )
+    expect(result.totals.taxReturn).toBe(result.salary.taxes.totalHalf)
+    expect(result.totals.monthlyNetWithTaxReturn).toBe(
+      roundEuros(result.totals.monthlyNet + result.totals.taxReturn),
+    )
+  })
+
+  it('should use custom director gross when specified', () => {
+    const result = calculateDoo(10000, { directorGross: 3000 })
+    expect(result.directorGross).toBe(3000)
+    expect(result.salary.gross).toBe(3000)
+    expect(result.variables.isDirectorMinimum).toBe(false)
+  })
+
+  it('should clamp profit to 0 when revenue is less than bruto2', () => {
+    const result = calculateDoo(1000)
+    expect(result.corporate.profit).toBe(0)
+    expect(result.corporate.corporateTax).toBe(0)
+    expect(result.corporate.profitAfterTax).toBe(0)
+    expect(result.dividend.netDividend).toBe(0)
+    expect(result.totals.netDividend).toBe(0)
+  })
+
+  it('should support place configuration', () => {
+    const result = calculateDoo(5000, { place: 'zagreb' })
+    expect(result.variables.place).toBe('zagreb')
+  })
+
+  it('should produce different salary net for different places', () => {
+    const resultDefault = calculateDoo(5000)
+    const resultZagreb = calculateDoo(5000, { place: 'zagreb' })
+    // Default rates (20%/30%) differ from Zagreb rates, so nets differ
+    expect(resultDefault.salary.net).not.toBe(resultZagreb.salary.net)
+  })
+
+  it('should throw for negative totalRevenue', () => {
+    expect(() => calculateDoo(-1)).toThrow()
+  })
+
+  it('should throw for non-finite totalRevenue', () => {
+    expect(() => calculateDoo(Infinity)).toThrow()
+    expect(() => calculateDoo(Number.NaN)).toThrow()
+  })
+
+  it('should throw for invalid directorGross', () => {
+    expect(() => calculateDoo(5000, { directorGross: -1 })).toThrow()
+  })
+})
+
+describe('calculateDooSimple', () => {
+  it('should return netSalary, netDividend, and total', () => {
+    const simple = calculateDooSimple(5000)
+    const full = calculateDoo(5000)
+
+    expect(simple.netSalary).toBe(full.totals.netSalary)
+    expect(simple.netDividend).toBe(full.totals.netDividend)
+    expect(simple.total).toBe(full.totals.monthlyNet)
+  })
+
+  it('should respect config options', () => {
+    const simple = calculateDooSimple(10000, { directorGross: 2000, place: 'zagreb' })
+    const full = calculateDoo(10000, { directorGross: 2000, place: 'zagreb' })
+
+    expect(simple.netSalary).toBe(full.totals.netSalary)
+    expect(simple.netDividend).toBe(full.totals.netDividend)
+    expect(simple.total).toBe(full.totals.monthlyNet)
+  })
+})

--- a/packages/core/src/calculations/doo.ts
+++ b/packages/core/src/calculations/doo.ts
@@ -1,0 +1,212 @@
+import type { Place } from '../data/places'
+import type { SalaryConfig } from './gross-to-net'
+import {
+  CORPORATE_TAX_RATE,
+  DIRECTOR_MINIMUM_GROSS,
+  DIVIDEND_TAX_RATE,
+} from '../constants'
+import { Decimal } from '../lib/decimal'
+import { assertFinitePositive, assertValidSalary, roundEuros } from '../utils/precision'
+import { grossToNetBreakdown } from './gross-to-net'
+
+export interface DooConfig {
+  /**
+   * Director's gross salary (bruto 1).
+   * Defaults to DIRECTOR_MINIMUM_GROSS (direktorski minimalac, €1,295.45).
+   */
+  directorGross?: number
+  place?: Place
+  taxRateLow?: number
+  taxRateHigh?: number
+  personalAllowanceCoefficient?: number
+  thirdPillarContribution?: number
+}
+
+export interface DooBreakdown {
+  totalRevenue: number
+  directorGross: number
+
+  salary: {
+    gross: number
+    totalCostToEmployer: number
+    healthInsurance: number
+    pension: {
+      firstPillar: number
+      secondPillar: number
+      mandatoryTotal: number
+      thirdPillar: number
+      total: number
+    }
+    income: number
+    personalAllowance: number
+    taxableIncome: number
+    taxes: {
+      lowerBracket: number
+      higherBracket: number
+      total: number
+      totalHalf: number
+    }
+    net: number
+  }
+
+  corporate: {
+    profit: number
+    corporateTaxRate: number
+    corporateTax: number
+    profitAfterTax: number
+  }
+
+  dividend: {
+    grossDividend: number
+    dividendTaxRate: number
+    dividendTax: number
+    netDividend: number
+  }
+
+  totals: {
+    netSalary: number
+    netDividend: number
+    monthlyNet: number
+    taxReturn: number
+    monthlyNetWithTaxReturn: number
+  }
+
+  variables: {
+    place: Place | undefined
+    taxRateLow: number
+    taxRateHigh: number
+    personalAllowanceCoefficient: number
+    corporateTaxRate: number
+    dividendTaxRate: number
+    directorMinimumGross: number
+    isDirectorMinimum: boolean
+  }
+}
+
+/**
+ * Calculates the full d.o.o. (Croatian LLC) salary + dividend breakdown.
+ *
+ * Given total monthly revenue and a director's gross salary, computes:
+ * - Net salary (via grossToNetBreakdown)
+ * - Corporate profit and tax (10%)
+ * - Dividend distribution and tax (12%)
+ * - Total take-home (net salary + net dividend)
+ *
+ * @note Kalkulator d.o.o. - plaća direktora + dividenda
+ *
+ * @param totalRevenue - Monthly gross revenue to the company (EUR).
+ * @param config - Optional configuration.
+ * @returns Full DOO breakdown.
+ */
+export function calculateDoo(totalRevenue: number, config: DooConfig = {}): DooBreakdown {
+  assertFinitePositive(totalRevenue, 'totalRevenue')
+
+  const directorGross = config.directorGross ?? DIRECTOR_MINIMUM_GROSS
+  assertValidSalary(directorGross, 'directorGross')
+
+  const isDirectorMinimum = config.directorGross == null
+    || config.directorGross === DIRECTOR_MINIMUM_GROSS
+
+  // Salary config for grossToNetBreakdown
+  const salaryConfig: SalaryConfig = {
+    place: config.place,
+    taxRateLow: config.taxRateLow,
+    taxRateHigh: config.taxRateHigh,
+    personalAllowanceCoefficient: config.personalAllowanceCoefficient,
+    thirdPillarContribution: config.thirdPillarContribution,
+  }
+
+  // Step 1: Calculate salary breakdown using existing function
+  const salaryBreakdown = grossToNetBreakdown(directorGross, salaryConfig)
+  const netSalary = salaryBreakdown.net
+  const bruto2 = salaryBreakdown.totalCostToEmployer
+
+  // Step 2: Corporate profit (clamped to 0 if revenue < salary cost)
+  const $revenue = new Decimal(totalRevenue)
+  const $bruto2 = new Decimal(bruto2)
+  const $rawProfit = $revenue.sub($bruto2)
+  const $profit = $rawProfit.greaterThan(0) ? $rawProfit : new Decimal(0)
+
+  const $corporateTax = $profit.mul(CORPORATE_TAX_RATE).toDP(2)
+  const $profitAfterTax = $profit.sub($corporateTax).toDP(2)
+
+  // Step 3: Dividend
+  const $dividendTax = $profitAfterTax.mul(DIVIDEND_TAX_RATE).toDP(2)
+  const $netDividend = $profitAfterTax.sub($dividendTax).toDP(2)
+
+  // Step 4: Totals
+  const $netSalary = new Decimal(netSalary)
+  const $monthlyNet = $netSalary.add($netDividend).toDP(2)
+  const taxReturn = salaryBreakdown.taxes.totalHalf
+  const $monthlyNetWithTaxReturn = $monthlyNet.add(taxReturn).toDP(2)
+
+  return {
+    totalRevenue: roundEuros(totalRevenue),
+    directorGross: roundEuros(directorGross),
+
+    salary: {
+      gross: salaryBreakdown.gross,
+      totalCostToEmployer: salaryBreakdown.totalCostToEmployer,
+      healthInsurance: salaryBreakdown.healthInsurance,
+      pension: salaryBreakdown.pension,
+      income: salaryBreakdown.income,
+      personalAllowance: salaryBreakdown.personalAllowance,
+      taxableIncome: salaryBreakdown.taxableIncome,
+      taxes: salaryBreakdown.taxes,
+      net: salaryBreakdown.net,
+    },
+
+    corporate: {
+      profit: roundEuros($profit.toNumber()),
+      corporateTaxRate: CORPORATE_TAX_RATE,
+      corporateTax: roundEuros($corporateTax.toNumber()),
+      profitAfterTax: roundEuros($profitAfterTax.toNumber()),
+    },
+
+    dividend: {
+      grossDividend: roundEuros($profitAfterTax.toNumber()),
+      dividendTaxRate: DIVIDEND_TAX_RATE,
+      dividendTax: roundEuros($dividendTax.toNumber()),
+      netDividend: roundEuros($netDividend.toNumber()),
+    },
+
+    totals: {
+      netSalary,
+      netDividend: roundEuros($netDividend.toNumber()),
+      monthlyNet: roundEuros($monthlyNet.toNumber()),
+      taxReturn,
+      monthlyNetWithTaxReturn: roundEuros($monthlyNetWithTaxReturn.toNumber()),
+    },
+
+    variables: {
+      place: config.place ?? undefined,
+      taxRateLow: salaryBreakdown.variables.taxRateLow,
+      taxRateHigh: salaryBreakdown.variables.taxRateHigh,
+      personalAllowanceCoefficient: salaryBreakdown.variables.personalAllowanceCoefficient,
+      corporateTaxRate: CORPORATE_TAX_RATE,
+      dividendTaxRate: DIVIDEND_TAX_RATE,
+      directorMinimumGross: DIRECTOR_MINIMUM_GROSS,
+      isDirectorMinimum,
+    },
+  }
+}
+
+/**
+ * Simplified d.o.o. calculation returning just net salary, net dividend, and total.
+ *
+ * @param totalRevenue - Monthly gross revenue to the company (EUR).
+ * @param config - Optional configuration.
+ * @returns Net salary, net dividend, and total monthly take-home.
+ */
+export function calculateDooSimple(totalRevenue: number, config: DooConfig = {}): {
+  netSalary: number
+  netDividend: number
+  total: number
+} {
+  const result = calculateDoo(totalRevenue, config)
+  return {
+    netSalary: result.totals.netSalary,
+    netDividend: result.totals.netDividend,
+    total: result.totals.monthlyNet,
+  }
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -60,3 +60,21 @@ export const MIN_PERSONAL_ALLOWANCE_COEFFICIENT = 0.3
  * The maximum personal allowance coefficient.
  */
 export const MAX_PERSONAL_ALLOWANCE_COEFFICIENT = 6
+
+/**
+ * Default director's minimum gross salary.
+ * @note direktorski minimalac
+ */
+export const DIRECTOR_MINIMUM_GROSS = 1_295.45
+
+/**
+ * Corporate income tax rate for companies with revenue < €1M.
+ * @note porez na dobit
+ */
+export const CORPORATE_TAX_RATE = percent(10)
+
+/**
+ * Tax rate on capital income (dividends).
+ * @note porez na dohodak od kapitala
+ */
+export const DIVIDEND_TAX_RATE = percent(12)

--- a/packages/web/app/components/DooCalculator.vue
+++ b/packages/web/app/components/DooCalculator.vue
@@ -1,0 +1,301 @@
+<script setup lang="ts">
+import type { Place } from '@brutoneto/core'
+import { useClipboard, useStorage } from '@vueuse/core'
+
+const DIRECTOR_MINIMUM_GROSS = 1_295.45
+
+type Props = {
+  selectedPlaceKey: Place
+  period: 'yearly' | 'monthly'
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (event: 'update:period', value: 'yearly' | 'monthly'): void
+}>()
+
+const selectedPlaceKey = toRef(props, 'selectedPlaceKey')
+const period = computed({
+  get: () => props.period,
+  set: (value: 'yearly' | 'monthly') => emit('update:period', value),
+})
+
+const revenue = useStorage<string>('doo-revenue', '')
+const directorGross = useStorage<string>('doo-director-gross', String(DIRECTOR_MINIMUM_GROSS))
+const useMinimumSalary = useStorage<boolean>('doo-use-minimum', true)
+
+const revenueNumber = computed(() => Number(revenue.value))
+const directorGrossNumber = computed(() =>
+  useMinimumSalary.value ? DIRECTOR_MINIMUM_GROSS : Number(directorGross.value),
+)
+
+const revenueLabel = computed(() => {
+  const periodLabel = period.value === 'yearly' ? 'Yearly' : 'Monthly'
+  return `${periodLabel} total revenue`
+})
+
+interface DooResponse {
+  totalRevenue: number
+  directorGross: number
+  salary: {
+    gross: number
+    net: number
+    totalCostToEmployer: number
+    healthInsurance: number
+    pension: {
+      firstPillar: number
+      secondPillar: number
+      mandatoryTotal: number
+      thirdPillar: number
+      total: number
+    }
+    income: number
+    personalAllowance: number
+    taxableIncome: number
+    taxes: {
+      lowerBracket: number
+      higherBracket: number
+      total: number
+      totalHalf: number
+    }
+  }
+  corporate: {
+    profit: number
+    corporateTaxRate: number
+    corporateTax: number
+    profitAfterTax: number
+  }
+  dividend: {
+    grossDividend: number
+    dividendTaxRate: number
+    dividendTax: number
+    netDividend: number
+  }
+  totals: {
+    netSalary: number
+    netDividend: number
+    monthlyNet: number
+    taxReturn: number
+    monthlyNetWithTaxReturn: number
+  }
+}
+
+const effectiveSalaryGross = computed(() =>
+  useMinimumSalary.value ? null : directorGrossNumber.value || null,
+)
+
+const { data, execute: calculate } = useFetch<DooResponse>(
+  () => `/api/doo/${revenue.value}`,
+  {
+    method: 'GET',
+    query: {
+      detailed: true,
+      yearly: computed(() => (period.value === 'yearly' ? 'true' : null)),
+      place: selectedPlaceKey,
+      salary_gross: effectiveSalaryGross,
+    },
+    immediate: false,
+    watch: false,
+    lazy: true,
+  },
+)
+
+const isInputValid = computed(() => {
+  if (!revenue.value || revenueNumber.value <= 0) return false
+  if (!useMinimumSalary.value) {
+    if (!directorGross.value || directorGrossNumber.value <= 0) return false
+  }
+  return true
+})
+
+const hasSubmittedOnce = ref(false)
+const revenueInputRef = ref<any>(null)
+const getRevenueInputEl = () =>
+  (revenueInputRef.value?.$el as HTMLElement | undefined)?.querySelector?.('input') as HTMLInputElement | null
+
+const handleCalculate = () => {
+  if (!isInputValid.value) return
+  hasSubmittedOnce.value = true
+  calculate()
+  getRevenueInputEl()?.blur()
+}
+
+watch(
+  () => selectedPlaceKey.value,
+  () => {
+    if (!hasSubmittedOnce.value || !isInputValid.value) return
+    handleCalculate()
+  },
+)
+
+const toYearly = (value: number) => value * 12
+
+const formattedData = computed(() =>
+  data.value ? JSON.stringify(data.value, null, 2) : '',
+)
+const { copy, copied } = useClipboard({ copiedDuring: 1200 })
+
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(value)
+}
+</script>
+
+<template>
+  <div>
+    <form @submit.prevent="handleCalculate">
+      <div class="flex flex-col gap-3">
+        <UFormField
+          :label="revenueLabel"
+          :ui="{ label: 'text-sm' }"
+        >
+          <UInput
+            ref="revenueInputRef"
+            v-model="revenue"
+            icon="mdi:currency-eur"
+            type="number"
+            placeholder="5000"
+            size="lg"
+            class="w-full sm:w-auto"
+            :ui="{ trailing: 'pe-1!' }"
+            autofocus
+          >
+            <template #trailing>
+              <UButton
+                color="primary"
+                variant="link"
+                size="lg"
+                icon="mdi:send"
+                type="submit"
+              />
+            </template>
+          </UInput>
+        </UFormField>
+
+        <div>
+          <div class="flex items-center gap-2 mb-1">
+            <label class="text-sm text-muted">Director's gross salary (bruto 1)</label>
+          </div>
+          <div class="flex items-center gap-3">
+            <UInput
+              v-model="directorGross"
+              icon="mdi:currency-eur"
+              type="number"
+              :placeholder="String(DIRECTOR_MINIMUM_GROSS)"
+              size="lg"
+              class="w-full sm:w-auto"
+              :disabled="useMinimumSalary"
+            />
+            <UTooltip text="Use minimum director salary (direktorski minimalac, €1,295.45)">
+              <label class="flex items-center gap-2 cursor-pointer whitespace-nowrap">
+                <input
+                  v-model="useMinimumSalary"
+                  type="checkbox"
+                  class="accent-primary"
+                >
+                <span class="text-sm text-muted">Minimalac</span>
+              </label>
+            </UTooltip>
+          </div>
+        </div>
+      </div>
+    </form>
+
+    <section v-if="data" class="mt-6 flex flex-col gap-3">
+      <div class="grid md:grid-cols-3 gap-3">
+        <UCard>
+          <template #header>
+            <h2 class="text-base font-bold uppercase font-unifontex text-foreground">
+              Net Salary
+            </h2>
+            <div class="flex flex-col gap-2">
+              <p class="text-4xl font-unifontex flex items-baseline gap-2">
+                <span class="text-foreground">
+                  {{ formatCurrency(data.totals.netSalary) }}
+                </span>
+                <span class="text-base text-muted">/mo</span>
+              </p>
+              <p class="text-lg text-muted font-unifontex">
+                {{ formatCurrency(toYearly(data.totals.netSalary)) }} /yr
+              </p>
+            </div>
+          </template>
+        </UCard>
+        <UCard>
+          <template #header>
+            <h2 class="text-base font-bold uppercase font-unifontex text-foreground">
+              Dividend
+            </h2>
+            <div class="flex flex-col gap-2">
+              <p class="text-4xl font-unifontex flex items-baseline gap-2">
+                <span class="text-foreground">
+                  {{ formatCurrency(data.totals.netDividend) }}
+                </span>
+                <span class="text-base text-muted">/mo</span>
+              </p>
+              <p class="text-lg text-muted font-unifontex">
+                {{ formatCurrency(toYearly(data.totals.netDividend)) }} /yr
+              </p>
+            </div>
+          </template>
+        </UCard>
+        <UCard>
+          <template #header>
+            <h2 class="text-base font-bold uppercase font-unifontex text-primary">
+              Total
+            </h2>
+            <div class="flex flex-col gap-2">
+              <p class="text-5xl font-unifontex flex items-baseline gap-2">
+                <span class="text-foreground">
+                  {{ formatCurrency(data.totals.monthlyNet) }}
+                </span>
+                <span class="text-base text-muted">/mo</span>
+              </p>
+              <p class="text-lg text-muted font-unifontex">
+                {{ formatCurrency(toYearly(data.totals.monthlyNet)) }} /yr
+              </p>
+              <p v-if="data.totals.taxReturn > 0" class="text-sm text-muted font-unifontex">
+                with tax return: {{ formatCurrency(data.totals.monthlyNetWithTaxReturn) }} /mo
+              </p>
+            </div>
+          </template>
+        </UCard>
+      </div>
+
+      <div>
+        <UCollapsible>
+          <UButton
+            label="Data"
+            color="neutral"
+            variant="ghost"
+            trailing-icon="mdi:chevron-down"
+            block
+          />
+
+          <template #content>
+            <div class="p-2 -mx-1">
+              <UCard>
+                <div class="flex items-center justify-between gap-2 pb-2">
+                  <p class="text-xs uppercase text-muted">
+                    Raw output
+                  </p>
+                  <UButton
+                    :label="copied ? 'Copied' : 'Copy'"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    icon="mdi:content-copy"
+                    @click="copy(formattedData)"
+                  />
+                </div>
+                <pre class="font-mono text-xs whitespace-pre-wrap">{{ formattedData }}</pre>
+              </UCard>
+            </div>
+          </template>
+        </UCollapsible>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/web/app/components/ModeSwitcher.vue
+++ b/packages/web/app/components/ModeSwitcher.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-type Mode = 'gross-to-net' | 'net-to-gross'
+type Mode = 'gross-to-net' | 'net-to-gross' | 'doo'
 
 type Props = {
   mode: Mode
@@ -60,6 +60,22 @@ const toggleMode = () =>
             :class="isActiveMode('gross-to-net') ? 'text-foreground font-bold' : 'text-muted'"
           >
             Net
+          </span>
+        </button>
+      </UTooltip>
+
+      <span class="text-muted mx-1">|</span>
+
+      <UTooltip
+        text="d.o.o. salary + dividend calculator"
+        :content="{ side: 'top' }"
+      >
+        <button type="button" @click="setMode('doo')">
+          <span
+            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex"
+            :class="isActiveMode('doo') ? 'text-foreground font-bold' : 'text-muted'"
+          >
+            d.o.o.
           </span>
         </button>
       </UTooltip>

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
 import type { Place } from '@brutoneto/core'
 
-type Mode = 'gross-to-net' | 'net-to-gross'
+type Mode = 'gross-to-net' | 'net-to-gross' | 'doo'
 type BrutoType = 'bruto1' | 'bruto2'
 
 const params = useUrlSearchParams('history')
 
 const mode = computed<Mode>({
-  get: () => (params.mode === 'nb' ? 'net-to-gross' : 'gross-to-net'),
+  get: () => {
+    if (params.mode === 'doo') return 'doo'
+    if (params.mode === 'nb') return 'net-to-gross'
+    return 'gross-to-net'
+  },
   set: (value) => {
-    if (value === 'net-to-gross') {
+    if (value === 'doo') {
+      params.mode = 'doo'
+    } else if (value === 'net-to-gross') {
       params.mode = 'nb'
     } else {
       delete params.mode
@@ -137,12 +143,19 @@ const places = computed(() => taxesRes.value?.places)
 
       <section class="mt-3">
         <SalaryCalculator
+          v-if="mode !== 'doo'"
           v-model:period="period"
           :mode="mode"
           :bruto-type="isActiveMode('gross-to-net') ? brutoType : 'bruto1'"
           :selected-place-key="selectedPlaceKey"
           :placeholder="isActiveMode('gross-to-net') ? (brutoType === 'bruto2' ? '4660' : '3000') : '2200'"
           autofocus
+        />
+
+        <DooCalculator
+          v-else
+          v-model:period="period"
+          :selected-place-key="selectedPlaceKey"
         />
       </section>
     </div>


### PR DESCRIPTION
## Summary
This PR adds a complete d.o.o. (Croatian limited liability company) calculator that computes net salary and dividend distributions based on company revenue and director's gross salary.

## Key Changes

### Core Calculation Logic
- **New `calculateDoo()` function** in `packages/core/src/calculations/doo.ts` that:
  - Takes total monthly revenue and optional director's gross salary (defaults to minimum of €1,295.45)
  - Calculates net salary using existing `grossToNetBreakdown()` function
  - Computes corporate profit and applies 10% corporate tax rate
  - Calculates dividend distribution and applies 12% dividend tax rate
  - Returns comprehensive breakdown including salary, corporate, dividend, and total take-home figures
  - Supports place-specific tax rates and custom salary configurations

- **New constants** in `packages/core/src/constants.ts`:
  - `DIRECTOR_MINIMUM_GROSS` (€1,295.45)
  - `CORPORATE_TAX_RATE` (10%)
  - `DIVIDEND_TAX_RATE` (12%)

- **Comprehensive test suite** in `packages/core/src/calculations/doo.test.ts` covering:
  - Default director minimum salary behavior
  - Salary calculation accuracy against existing functions
  - Corporate and dividend tax calculations
  - Edge cases (negative revenue, insufficient profit for dividends)
  - Place-specific configurations

### API Endpoint
- **New endpoint** `packages/api/server/api/doo/[totalRevenue].get.ts` that:
  - Accepts total revenue as path parameter
  - Supports optional query parameters: `salary_gross`, `place`, `ltax`, `htax`, `coeff`, `third_pillar`
  - Supports `detailed` flag for full breakdown vs. simplified response
  - Supports `yearly` flag to convert annual revenue to monthly
  - Returns detailed DOO breakdown or simplified summary

### UI Components
- **New `DooCalculator.vue` component** in `packages/web/app/components/DooCalculator.vue`:
  - Input fields for monthly/yearly revenue and director's gross salary
  - Checkbox to use minimum director salary (direktorski minimalac)
  - Displays net salary, dividend, and total take-home with monthly/yearly views
  - Collapsible section showing raw API response
  - Copy-to-clipboard functionality for detailed data
  - Reactive calculations with URL parameter persistence

- **Updated `ModeSwitcher.vue`** to include d.o.o. mode toggle alongside existing gross-to-net and net-to-gross modes

- **Updated main page** (`packages/web/app/pages/index.vue`) to:
  - Add 'd.o.o.' as a third calculation mode
  - Conditionally render `DooCalculator` when d.o.o. mode is active
  - Manage mode state in URL parameters

### Exports
- Updated `packages/core/index.ts` to export new DOO calculation functions and constants

## Implementation Details
- Leverages existing `grossToNetBreakdown()` for accurate salary calculations
- Uses `Decimal` library for precise financial calculations
- Clamps corporate profit to 0 when revenue is insufficient to cover salary costs
- Supports all existing salary configuration options (place, tax rates, personal allowance, third pillar contributions)
- Maintains consistency with existing calculation patterns and error handling

https://claude.ai/code/session_01GTuNiHGJbRapwn6FJKXo5n