### PR TITLE
Add dividend withdrawal percentage control to DOO calculator

### DIFF
--- a/packages/api/server/api/doo/[totalRevenue].get.ts
+++ b/packages/api/server/api/doo/[totalRevenue].get.ts
@@ -39,6 +39,7 @@ const QuerySchema = z.object({
       message: `Maximum allowed non-taxable monthly third pillar contribution is €${THIRD_PILLAR_NON_TAXABLE_LIMIT}`,
     })
     .optional(),
+  dividend_pct: z.coerce.number().min(0).max(100).optional(),
   detailed: z.coerce.boolean().optional(),
   yearly: z.coerce.boolean().optional(),
 })
@@ -68,7 +69,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { salary_gross, place, ltax, htax, coeff, third_pillar, detailed, yearly } = query.data
+  const { salary_gross, place, ltax, htax, coeff, third_pillar, dividend_pct, detailed, yearly } = query.data
 
   const monthlyRevenue = yearly === true ? roundEuros(totalRevenue / 12) : totalRevenue
 
@@ -81,6 +82,7 @@ export default defineEventHandler(async (event) => {
     taxRateHigh: htax,
     personalAllowanceCoefficient: coeff,
     thirdPillarContribution: third_pillar,
+    dividendPercentage: dividend_pct,
   }
 
   if (detailed === true) {

--- a/packages/web/app/components/DooCalculator.vue
+++ b/packages/web/app/components/DooCalculator.vue
@@ -171,7 +171,8 @@ const adjustedDividend = computed(() => {
   const monthlyNet = Math.round((netSalary + netDividend) * 100) / 100
   const taxReturn = data.value.totals.taxReturn
   const monthlyNetWithTaxReturn = Math.round((monthlyNet + taxReturn) * 100) / 100
-  return { netDividend, retained, monthlyNet, monthlyNetWithTaxReturn }
+  const totalWithRetained = Math.round((monthlyNet + retained) * 100) / 100
+  return { netDividend, retained, monthlyNet, monthlyNetWithTaxReturn, totalWithRetained }
 })
 
 const formattedData = computed(() =>
@@ -318,46 +319,51 @@ const formatCurrency = (value: number) => {
         </UCard>
       </div>
 
-      <UCard>
-        <template #header>
-          <h2 class="text-base font-bold uppercase font-unifontex text-primary">
-            Total
-          </h2>
-          <div class="flex flex-col gap-2">
-            <p class="text-5xl font-unifontex flex items-baseline gap-2">
-              <span class="text-foreground">
-                {{ formatCurrency(adjustedDividend?.monthlyNet ?? data.totals.monthlyNet) }}
-              </span>
-              <span class="text-base text-muted">/mo</span>
-            </p>
-            <p class="text-lg text-muted font-unifontex">
-              {{ formatCurrency(toYearly(adjustedDividend?.monthlyNet ?? data.totals.monthlyNet)) }} /yr
-            </p>
-            <p v-if="data.totals.taxReturn > 0" class="text-sm text-muted font-unifontex">
-              with tax return: {{ formatCurrency(adjustedDividend?.monthlyNetWithTaxReturn ?? data.totals.monthlyNetWithTaxReturn) }} /mo
-            </p>
-          </div>
-        </template>
-      </UCard>
+      <div class="grid gap-3" :class="adjustedDividend && adjustedDividend.retained > 0 ? 'md:grid-cols-2' : ''">
+        <UCard>
+          <template #header>
+            <h2 class="text-base font-bold uppercase font-unifontex text-primary">
+              Total
+            </h2>
+            <div class="flex flex-col gap-2">
+              <p class="text-5xl font-unifontex flex items-baseline gap-2">
+                <span class="text-foreground">
+                  {{ formatCurrency(adjustedDividend?.monthlyNet ?? data.totals.monthlyNet) }}
+                </span>
+                <span class="text-base text-muted">/mo</span>
+              </p>
+              <p class="text-lg text-muted font-unifontex">
+                {{ formatCurrency(toYearly(adjustedDividend?.monthlyNet ?? data.totals.monthlyNet)) }} /yr
+              </p>
+              <p v-if="data.totals.taxReturn > 0" class="text-sm text-muted font-unifontex">
+                with tax return: {{ formatCurrency(adjustedDividend?.monthlyNetWithTaxReturn ?? data.totals.monthlyNetWithTaxReturn) }} /mo
+              </p>
+              <p v-if="adjustedDividend && adjustedDividend.retained > 0" class="text-sm text-muted font-unifontex">
+                incl. company balance: {{ formatCurrency(adjustedDividend.totalWithRetained) }} /mo
+              </p>
+            </div>
+          </template>
+        </UCard>
 
-      <UCard v-if="adjustedDividend && adjustedDividend.retained > 0" variant="subtle">
-        <template #header>
-          <h2 class="text-base font-bold uppercase font-unifontex text-muted">
-            Remains in company
-          </h2>
-          <div class="flex flex-col gap-2">
-            <p class="text-5xl font-unifontex flex items-baseline gap-2">
-              <span class="text-foreground">
-                {{ formatCurrency(adjustedDividend.retained) }}
-              </span>
-              <span class="text-base text-muted">/mo</span>
-            </p>
-            <p class="text-lg text-muted font-unifontex">
-              {{ formatCurrency(toYearly(adjustedDividend.retained)) }} /yr
-            </p>
-          </div>
-        </template>
-      </UCard>
+        <UCard v-if="adjustedDividend && adjustedDividend.retained > 0" variant="subtle">
+          <template #header>
+            <h2 class="text-base font-bold uppercase font-unifontex text-muted">
+              Company balance
+            </h2>
+            <div class="flex flex-col gap-2">
+              <p class="text-5xl font-unifontex flex items-baseline gap-2">
+                <span class="text-foreground">
+                  {{ formatCurrency(adjustedDividend.retained) }}
+                </span>
+                <span class="text-base text-muted">/mo</span>
+              </p>
+              <p class="text-lg text-muted font-unifontex">
+                {{ formatCurrency(toYearly(adjustedDividend.retained)) }} /yr
+              </p>
+            </div>
+          </template>
+        </UCard>
+      </div>
 
       <div>
         <UCollapsible>

--- a/packages/web/app/components/DooCalculator.vue
+++ b/packages/web/app/components/DooCalculator.vue
@@ -170,6 +170,12 @@ watch(
 
 const toYearly = (value: number) => value * 12
 
+const retainedEarnings = computed(() => {
+  if (!data.value) return 0
+  return data.value.corporate.retainedEarnings
+    ?? (data.value.corporate.profitAfterTax - data.value.dividend.grossDividend)
+})
+
 const formattedData = computed(() =>
   data.value ? JSON.stringify(data.value, null, 2) : '',
 )
@@ -336,7 +342,7 @@ const formatCurrency = (value: number) => {
         </template>
       </UCard>
 
-      <UCard v-if="data.corporate.retainedEarnings > 0" variant="subtle">
+      <UCard v-if="retainedEarnings > 0" variant="subtle">
         <template #header>
           <h2 class="text-base font-bold uppercase font-unifontex text-muted">
             Remains in company
@@ -344,12 +350,12 @@ const formatCurrency = (value: number) => {
           <div class="flex flex-col gap-2">
             <p class="text-5xl font-unifontex flex items-baseline gap-2">
               <span class="text-foreground">
-                {{ formatCurrency(data.corporate.retainedEarnings) }}
+                {{ formatCurrency(retainedEarnings) }}
               </span>
               <span class="text-base text-muted">/mo</span>
             </p>
             <p class="text-lg text-muted font-unifontex">
-              {{ formatCurrency(toYearly(data.corporate.retainedEarnings)) }} /yr
+              {{ formatCurrency(toYearly(retainedEarnings)) }} /yr
             </p>
           </div>
         </template>


### PR DESCRIPTION
## Summary
This PR adds the ability to control what percentage of after-tax corporate profit is withdrawn as a dividend, with the remainder retained in the company. Previously, 100% of profit after corporate tax was always withdrawn as dividend.

## Key Changes

- **New `dividendPercentage` configuration option** (0–100, defaults to 100):
  - Added to `DooConfig` interface with validation
  - Allows users to specify what portion of profit after corporate tax to withdraw as dividend
  - Remainder automatically retained in the company as `retainedEarnings`

- **Updated dividend calculation logic**:
  - `grossDividend` now calculated as `profitAfterTax × (dividendPercentage / 100)`
  - New `retainedEarnings` field tracks profit kept in company: `profitAfterTax - grossDividend`
  - Dividend tax and net dividend calculated only on the withdrawn amount
  - Retained earnings do not affect take-home calculations

- **Frontend UI enhancements**:
  - New "Dividend withdrawal %" input field with validation (0–100)
  - "Use 100%" quick-action button
  - New "Remains in company" card displays retained earnings when > 0
  - Form validation includes dividend percentage checks
  - Auto-recalculation on dividend percentage changes

- **API endpoint updates**:
  - Added `dividend_pct` query parameter to `/api/doo/[totalRevenue]` endpoint
  - Parameter validation ensures value is between 0 and 100

- **Comprehensive test coverage**:
  - Tests for default 100% behavior
  - Tests for partial withdrawals (50%, etc.)
  - Tests for 0% retention (no dividend)
  - Validation that `retainedEarnings + grossDividend === profitAfterTax`
  - Verification that salary calculations remain unaffected
  - Boundary validation tests

## Implementation Details

- Dividend percentage is stored in browser localStorage for persistence
- Validation prevents invalid values (< 0 or > 100) at both frontend and backend
- Retained earnings calculation uses proper decimal arithmetic to avoid floating-point errors
- The feature is backward compatible—existing calculations default to 100% withdrawal

https://claude.ai/code/session_01PZxzgEYf1M2bD4cMz6rKrw