### PR TITLE
Fix mode highlighting by using Nuxt route query

### DIFF
--- a/packages/web/app/components/ModeSwitcher.vue
+++ b/packages/web/app/components/ModeSwitcher.vue
@@ -30,8 +30,8 @@ const toggleMode = () =>
       >
         <button type="button" @click="setMode('net-to-gross')">
           <span
-            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex"
-            :class="isActiveMode('net-to-gross') ? 'text-foreground font-bold' : 'text-muted'"
+            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex font-bold"
+            :class="isActiveMode('net-to-gross') ? 'text-foreground' : 'text-muted'"
           >
             Gross
           </span>
@@ -56,8 +56,8 @@ const toggleMode = () =>
       >
         <button type="button" @click="setMode('gross-to-net')">
           <span
-            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex"
-            :class="isActiveMode('gross-to-net') ? 'text-foreground font-bold' : 'text-muted'"
+            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex font-bold"
+            :class="isActiveMode('gross-to-net') ? 'text-foreground' : 'text-muted'"
           >
             Net
           </span>
@@ -72,8 +72,8 @@ const toggleMode = () =>
       >
         <button type="button" @click="setMode('doo')">
           <span
-            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex"
-            :class="isActiveMode('doo') ? 'text-foreground font-bold' : 'text-muted'"
+            class="text-2xl sm:text-lg uppercase tracking-wide font-unifontex font-bold"
+            :class="isActiveMode('doo') ? 'text-foreground' : 'text-muted'"
           >
             d.o.o.
           </span>

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -4,47 +4,46 @@ import type { Place } from '@brutoneto/core'
 type Mode = 'gross-to-net' | 'net-to-gross' | 'doo'
 type BrutoType = 'bruto1' | 'bruto2'
 
-const params = useUrlSearchParams('history')
+const route = useRoute()
+const router = useRouter()
+
+function replaceQuery(updates: Record<string, string | undefined>) {
+  const query = { ...route.query }
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete query[key]
+    } else {
+      query[key] = value
+    }
+  }
+  router.replace({ query })
+}
 
 const mode = computed<Mode>({
   get: () => {
-    if (params.mode === 'doo') return 'doo'
-    if (params.mode === 'nb') return 'net-to-gross'
+    if (route.query.mode === 'doo') return 'doo'
+    if (route.query.mode === 'nb') return 'net-to-gross'
     return 'gross-to-net'
   },
   set: (value) => {
-    if (value === 'doo') {
-      params.mode = 'doo'
-    } else if (value === 'net-to-gross') {
-      params.mode = 'nb'
-    } else {
-      delete params.mode
-    }
-    delete params.bruto
+    const modeParam = value === 'doo' ? 'doo' : value === 'net-to-gross' ? 'nb' : undefined
+    replaceQuery({ mode: modeParam, bruto: undefined })
   },
 })
 const isActiveMode = (value: Mode) => mode.value === value
 const brutoType = computed<BrutoType>({
-  get: () => (params.bruto === '2' ? 'bruto2' : 'bruto1'),
+  get: () => (route.query.bruto === '2' ? 'bruto2' : 'bruto1'),
   set: (value) => {
-    if (value === 'bruto2') {
-      params.bruto = '2'
-    } else {
-      delete params.bruto
-    }
+    replaceQuery({ bruto: value === 'bruto2' ? '2' : undefined })
   },
 })
 const selectedPlaceKey = useCookie<Place>('place', {
   default: () => 'sveta-nedelja-samobor',
 })
 const period = computed<'yearly' | 'monthly'>({
-  get: () => (params.period === 'yr' ? 'yearly' : 'monthly'),
+  get: () => (route.query.period === 'yr' ? 'yearly' : 'monthly'),
   set: (value) => {
-    if (value === 'yearly') {
-      params.period = 'yr'
-    } else {
-      delete params.period
-    }
+    replaceQuery({ period: value === 'yearly' ? 'yr' : undefined })
   },
 })
 

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -123,7 +123,7 @@ const places = computed(() => taxesRes.value?.places)
           </USelectMenu>
         </UFormField>
         <UFormField
-          v-if="isActiveMode('gross-to-net')"
+          v-show="isActiveMode('gross-to-net')"
           label="Type"
           :ui="{ label: 'text-sm' }"
         >


### PR DESCRIPTION


useUrlSearchParams from VueUse does not work with SSR, causing hydration mismatches where the server always renders gross-to-net (default) regardless of the actual URL params. This resulted in multiple modes appearing highlighted simultaneously and DOO mode not being selected on page refresh.

Replaced with Nuxt's useRoute/useRouter which are SSR-compatible and read the correct query params on both server and client.

https://claude.ai/code/session_012eTzNDbArsoqNHewcfGN25