### PR TITLE
Add multi-currency input support (USD) for salary and D.o.o. calculators

### DIFF
--- a/packages/web/app/composables/useCurrency.ts
+++ b/packages/web/app/composables/useCurrency.ts
@@ -2,6 +2,14 @@ import { useStorage } from '@vueuse/core'
 
 export type InputCurrency = 'EUR' | 'USD'
 
+export interface CurrencySubmission {
+  eurAmount: number
+  inputAmount: number
+  currency: InputCurrency
+  period: 'yearly' | 'monthly'
+  rate: number | null
+}
+
 interface ExchangeRateResponse {
   from: string
   to: string
@@ -23,7 +31,6 @@ export function useCurrency() {
   )
 
   const exchangeRate = computed(() => rateData.value?.rate ?? null)
-  const exchangeRateDate = computed(() => rateData.value?.date ?? null)
   const isLoadingRate = computed(() => rateStatus.value === 'pending')
   const isNonEur = computed(() => currency.value !== 'EUR')
 
@@ -40,10 +47,10 @@ export function useCurrency() {
     return Math.round(amount * exchangeRate.value * 100) / 100
   }
 
-  function formatInputCurrency(value: number): string {
+  function formatInputCurrency(value: number, overrideCurrency?: InputCurrency): string {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: currency.value,
+      currency: overrideCurrency ?? currency.value,
     }).format(value)
   }
 
@@ -51,20 +58,13 @@ export function useCurrency() {
     return currency.value === 'USD' ? 'mdi:currency-usd' : 'mdi:currency-eur'
   })
 
-  const currencySymbol = computed(() => {
-    return currency.value === 'USD' ? '$' : '€'
-  })
-
   return {
     currency,
     exchangeRate,
-    exchangeRateDate,
     isLoadingRate,
     isNonEur,
     convertToEur,
     formatInputCurrency,
     currencyIcon,
-    currencySymbol,
-    fetchRate,
   }
 }

--- a/packages/web/app/composables/useCurrency.ts
+++ b/packages/web/app/composables/useCurrency.ts
@@ -1,0 +1,70 @@
+import { useStorage } from '@vueuse/core'
+
+export type InputCurrency = 'EUR' | 'USD'
+
+interface ExchangeRateResponse {
+  from: string
+  to: string
+  rate: number
+  date: string
+  stale?: boolean
+}
+
+export function useCurrency() {
+  const currency = useStorage<InputCurrency>('input-currency', 'EUR')
+
+  const { data: rateData, status: rateStatus, execute: fetchRate } = useFetch<ExchangeRateResponse>(
+    '/api/exchange-rate',
+    {
+      immediate: false,
+      watch: false,
+      lazy: true,
+    },
+  )
+
+  const exchangeRate = computed(() => rateData.value?.rate ?? null)
+  const exchangeRateDate = computed(() => rateData.value?.date ?? null)
+  const isLoadingRate = computed(() => rateStatus.value === 'pending')
+  const isNonEur = computed(() => currency.value !== 'EUR')
+
+  // Fetch rate when USD is selected
+  watch(currency, (val) => {
+    if (val === 'USD' && !rateData.value) {
+      fetchRate()
+    }
+  }, { immediate: true })
+
+  function convertToEur(amount: number): number | null {
+    if (currency.value === 'EUR') return amount
+    if (!exchangeRate.value) return null
+    return Math.round(amount * exchangeRate.value * 100) / 100
+  }
+
+  function formatInputCurrency(value: number): string {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency.value,
+    }).format(value)
+  }
+
+  const currencyIcon = computed(() => {
+    return currency.value === 'USD' ? 'mdi:currency-usd' : 'mdi:currency-eur'
+  })
+
+  const currencySymbol = computed(() => {
+    return currency.value === 'USD' ? '$' : '€'
+  })
+
+  return {
+    currency,
+    exchangeRate,
+    exchangeRateDate,
+    isLoadingRate,
+    isNonEur,
+    convertToEur,
+    formatInputCurrency,
+    currencyIcon,
+    currencySymbol,
+    fetchRate,
+  }
+}

--- a/packages/web/server/routes/api/exchange-rate.get.ts
+++ b/packages/web/server/routes/api/exchange-rate.get.ts
@@ -1,0 +1,60 @@
+interface CachedRate {
+  rate: number
+  timestamp: string
+  cachedAt: number
+}
+
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+let cachedRate: CachedRate | null = null
+
+async function fetchUsdToEurRate(): Promise<{ rate: number, timestamp: string }> {
+  const res = await fetch('https://api.frankfurter.app/latest?from=USD&to=EUR')
+  if (!res.ok) {
+    throw new Error(`Exchange rate API returned ${res.status}`)
+  }
+  const data = await res.json() as { rates: { EUR: number }, date: string }
+  return {
+    rate: data.rates.EUR,
+    timestamp: data.date,
+  }
+}
+
+export default defineEventHandler(async () => {
+  const now = Date.now()
+
+  if (cachedRate && (now - cachedRate.cachedAt) < CACHE_TTL_MS) {
+    return {
+      from: 'USD',
+      to: 'EUR',
+      rate: cachedRate.rate,
+      date: cachedRate.timestamp,
+    }
+  }
+
+  try {
+    const { rate, timestamp } = await fetchUsdToEurRate()
+    cachedRate = { rate, timestamp, cachedAt: now }
+    return {
+      from: 'USD',
+      to: 'EUR',
+      rate,
+      date: timestamp,
+    }
+  }
+  catch (error) {
+    // If we have a stale cache, use it rather than failing
+    if (cachedRate) {
+      return {
+        from: 'USD',
+        to: 'EUR',
+        rate: cachedRate.rate,
+        date: cachedRate.timestamp,
+        stale: true,
+      }
+    }
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to fetch exchange rate',
+    })
+  }
+})


### PR DESCRIPTION
Allow entering amounts in USD with automatic conversion to EUR using
ECB exchange rates via frankfurter.app. All calculation results remain
in EUR. Adds a currency toggle on input fields, a conversion note in
results showing the original amount and exchange rate used, and a
server-side exchange rate endpoint with 1-hour caching.

https://claude.ai/code/session_01W5i8RdyED4T8RXKo4t8et2