### PR TITLE
Add tax return selector, tab isolation, and code cleanup

### DIFF
--- a/packages/api/server/api/doo/[totalRevenue].get.ts
+++ b/packages/api/server/api/doo/[totalRevenue].get.ts
@@ -39,7 +39,8 @@ const QuerySchema = z.object({
       message: `Maximum allowed non-taxable monthly third pillar contribution is €${THIRD_PILLAR_NON_TAXABLE_LIMIT}`,
     })
     .optional(),
-  dividend_pct: z.coerce.number().min(0).max(100).optional(),
+  dividend_percent: z.coerce.number().min(0).max(100).optional(),
+  tax_return_percent: z.coerce.number().min(0).max(100).optional(),
   detailed: z.coerce.boolean().optional(),
   yearly: z.coerce.boolean().optional(),
 })
@@ -69,7 +70,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { salary_gross, place, ltax, htax, coeff, third_pillar, dividend_pct, detailed, yearly } = query.data
+  const { salary_gross, place, ltax, htax, coeff, third_pillar, dividend_percent, tax_return_percent, detailed, yearly } = query.data
 
   const monthlyRevenue = yearly === true ? roundEuros(totalRevenue / 12) : totalRevenue
 
@@ -82,7 +83,8 @@ export default defineEventHandler(async (event) => {
     taxRateHigh: htax,
     personalAllowanceCoefficient: coeff,
     thirdPillarContribution: third_pillar,
-    dividendPercentage: dividend_pct,
+    dividendPercentage: dividend_percent,
+    taxReturnPercentage: tax_return_percent,
   }
 
   if (detailed === true) {

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -40,9 +40,13 @@ const brutoType = computed<BrutoType>({
 const selectedPlaceKey = useCookie<Place>('place', {
   default: () => 'sveta-nedelja-samobor',
 })
+const periodCookie = useCookie<'yearly' | 'monthly'>('period', {
+  default: () => 'monthly',
+})
 const period = computed<'yearly' | 'monthly'>({
-  get: () => (route.query.period === 'yr' ? 'yearly' : 'monthly'),
+  get: () => (route.query.period === 'yr' ? 'yearly' : periodCookie.value),
   set: (value) => {
+    periodCookie.value = value
     replaceQuery({ period: value === 'yearly' ? 'yr' : undefined })
   },
 })

--- a/packages/web/app/pages/index.vue
+++ b/packages/web/app/pages/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Place } from '@brutoneto/core'
+import { useLocalStorage } from '@vueuse/core'
 
 type Mode = 'gross-to-net' | 'net-to-gross' | 'doo'
 type BrutoType = 'bruto1' | 'bruto2'
@@ -50,6 +51,16 @@ const period = computed<'yearly' | 'monthly'>({
     replaceQuery({ period: value === 'yearly' ? 'yr' : undefined })
   },
 })
+
+const taxReturnPercent = useLocalStorage<number>('tax-return-percent', 0)
+const hasMounted = ref(false)
+onMounted(() => hasMounted.value = true)
+
+const taxReturnOptions = [
+  { label: 'None', value: 0 },
+  { label: '50%', value: 50 },
+  { label: '100%', value: 100 },
+]
 
 const { data: taxesRes, status: taxesStatus } = useFetch<{ places: {
   key: Place
@@ -142,6 +153,30 @@ const places = computed(() => taxesRes.value?.places)
             size="lg"
           />
         </UFormField>
+        <UFormField
+          label="Tax return"
+          :ui="{ label: 'text-sm' }"
+        >
+          <div class="flex">
+            <button
+              v-for="(opt, i) in taxReturnOptions"
+              :key="opt.value"
+              type="button"
+              class="relative px-3.5 py-2 text-sm border cursor-pointer transition-colors"
+              :class="[
+                hasMounted && taxReturnPercent === opt.value
+                  ? 'z-10 border-primary bg-primary/10 text-primary font-medium'
+                  : 'border-muted text-dimmed hover:text-foreground hover:border-accented',
+                i === 0 ? 'rounded-l-md' : '',
+                i === taxReturnOptions.length - 1 ? 'rounded-r-md' : '',
+                i > 0 ? '-ml-px' : '',
+              ]"
+              @click="taxReturnPercent = opt.value"
+            >
+              {{ opt.label }}
+            </button>
+          </div>
+        </UFormField>
       </div>
 
       <section class="mt-3">
@@ -152,6 +187,7 @@ const places = computed(() => taxesRes.value?.places)
           :bruto-type="isActiveMode('gross-to-net') ? brutoType : 'bruto1'"
           :selected-place-key="selectedPlaceKey"
           :placeholder="isActiveMode('gross-to-net') ? (brutoType === 'bruto2' ? '4660' : '3000') : '2200'"
+          :tax-return-percent="taxReturnPercent"
           autofocus
         />
 
@@ -159,6 +195,7 @@ const places = computed(() => taxesRes.value?.places)
           v-else
           v-model:period="period"
           :selected-place-key="selectedPlaceKey"
+          :tax-return-percent="taxReturnPercent"
         />
       </section>
     </div>


### PR DESCRIPTION
## Summary
- **Tab isolation**: Switch `useStorage(localStorage)` → `useSessionStorage` so input values don't sync across tabs
- **Tax return**: Configurable percentage (None/50%/100%) in core, API, and frontend — displays "with tax return" line in both Salary and D.o.o. calculators
- **API**: Rename `dividend_pct` → `dividend_percent`, add `tax_return_percent` param, support `detailed` mode in `/api/bruto`
- **Code cleanup**: Deduplicate `formatEur`, `toYearly`, `toggleCurrency`, `conversionNote` into `useCurrency` composable; import `DooBreakdown`/`DIRECTOR_MINIMUM_GROSS` from core; replace `Math.round` with `roundEuros`

## Test plan
- [x] All 2225 tests pass
- [x] Typecheck passes
- [x] Full build succeeds
- [ ] Tax return selector visible, defaults to None, persists in localStorage across refresh
- [ ] Salary: "with tax return" shows under Net card when % > 0
- [ ] D.o.o.: tax return updates instantly when changing selector
- [ ] Two tabs don't sync input values